### PR TITLE
csvlint のジョブ名を「Build」から「CSV構文チェック」に変更

### DIFF
--- a/.github/workflows/csvlint.yml
+++ b/.github/workflows/csvlint.yml
@@ -6,7 +6,7 @@ on:
     branches: [ main ]
 jobs:
   build:
-    name: Build
+    name: CSV構文チェック
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x


### PR DESCRIPTION
### 修正の概要

csvlint のジョブ名が単に「Build」になっていたので、もっとわかりやすくするため「CSV構文チェック」に変更します。

### 関連する Issues / PRs

なし <!-- 必要に応じて番号とタイトルを列挙してください -->

-----

セルフチェック

- [x] 収録基準への準拠を確認しました
- [x] スタイルガイドへの準拠を確認しました
- [x] 適切なラベル ("追加", "誤植" 等) を設定しました
